### PR TITLE
Refactor: trade slightly higher execution time for less memory allocation

### DIFF
--- a/ratelimiter.go
+++ b/ratelimiter.go
@@ -164,7 +164,7 @@ func (q *Limiter) Check(from Identity) (limited bool) {
 func (q *Limiter) Peek(from Identity) bool {
 	q.Patrons.DeleteExpired()
 	if ct, ok := q.Patrons.Get(from.UniqueKey()); ok {
-		count := ct.(int64)
+		count := ct.(*atomic.Int64).Load()
 		if count > q.Ruleset.Burst {
 			return true
 		}

--- a/ratelimiter_test.go
+++ b/ratelimiter_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
@@ -305,7 +306,7 @@ testloop:
 		if ci, ok = limiter.Patrons.Get(rp.UniqueKey()); !ok {
 			t.Fatal("randomPatron does not exist in ratelimiter at all!")
 		}
-		ct := ci.(int64)
+		ct := ci.(*atomic.Int64).Load()
 		if limiter.Peek(rp) && !shouldLimit {
 			t.Logf("(%d goroutines running)", runtime.NumGoroutine())
 			// runtime.Breakpoint()

--- a/ratelimiter_test.go
+++ b/ratelimiter_test.go
@@ -346,3 +346,101 @@ func Test_debugChannelOverflow(t *testing.T) {
 		t.Fatalf("debug channel did not overflow")
 	}
 }
+
+func BenchmarkCheck(b *testing.B) {
+	b.StopTimer()
+	b.ReportAllocs()
+	limiter := NewDefaultLimiter()
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		limiter.Check(dummyTicker)
+	}
+}
+
+func BenchmarkCheckHardcore(b *testing.B) {
+	b.StopTimer()
+	b.ReportAllocs()
+	limiter := NewHardcoreLimiter(25, 25)
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		limiter.Check(dummyTicker)
+	}
+}
+
+func BenchmarkCheckStrict(b *testing.B) {
+	b.StopTimer()
+	b.ReportAllocs()
+	limiter := NewStrictLimiter(25, 25)
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		limiter.Check(dummyTicker)
+	}
+}
+
+func BenchmarkCheckStringer(b *testing.B) {
+	b.StopTimer()
+	b.ReportAllocs()
+	limiter := NewDefaultLimiter()
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		limiter.CheckStringer(dummyTicker)
+	}
+}
+
+func BenchmarkPeek(b *testing.B) {
+	b.StopTimer()
+	b.ReportAllocs()
+	limiter := NewDefaultLimiter()
+	b.StartTimer()
+	for n := 0; n < b.N; n++ {
+		limiter.Peek(dummyTicker)
+	}
+}
+
+func BenchmarkConcurrentCheck(b *testing.B) {
+	b.StopTimer()
+	b.ReportAllocs()
+	limiter := NewDefaultLimiter()
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			limiter.Check(dummyTicker)
+		}
+	})
+}
+
+func BenchmarkConcurrentSetAndCheckHardcore(b *testing.B) {
+	b.StopTimer()
+	b.ReportAllocs()
+	limiter := NewHardcoreLimiter(25, 25)
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			limiter.Check(dummyTicker)
+		}
+	})
+}
+
+func BenchmarkConcurrentSetAndCheckStrict(b *testing.B) {
+	b.StopTimer()
+	b.ReportAllocs()
+	limiter := NewDefaultStrictLimiter()
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			limiter.Check(dummyTicker)
+		}
+	})
+}
+
+func BenchmarkConcurrentPeek(b *testing.B) {
+	b.StopTimer()
+	b.ReportAllocs()
+	limiter := NewDefaultLimiter()
+	b.StartTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			limiter.Peek(dummyTicker)
+		}
+	})
+}


### PR DESCRIPTION
## Original

```
goos: linux
goarch: amd64
pkg: github.com/yunginnanet/Rate5
cpu: 13th Gen Intel(R) Core(TM) i9-13900K
BenchmarkCheck
BenchmarkCheck-32                            	8302140	      143.9 ns/op	     40 B/op	      3 allocs/op
BenchmarkCheckHardcore
BenchmarkCheckHardcore-32                    	3354300	      355.3 ns/op	     63 B/op	      5 allocs/op
BenchmarkCheckStrict
BenchmarkCheckStrict-32                      	3332241	      355.4 ns/op	     63 B/op	      5 allocs/op
BenchmarkCheckStringer
BenchmarkCheckStringer-32                    	7158397	      177.2 ns/op	     56 B/op	      4 allocs/op
BenchmarkPeek
BenchmarkPeek-32                             	13619250	       88.06 ns/op	      0 B/op	      0 allocs/op
BenchmarkConcurrentCheck
BenchmarkConcurrentCheck-32                  	4704564	      249.1 ns/op	     40 B/op	      3 allocs/op
BenchmarkConcurrentSetAndCheckHardcore
BenchmarkConcurrentSetAndCheckHardcore-32    	2077162	      581.3 ns/op	     63 B/op	      5 allocs/op
BenchmarkConcurrentSetAndCheckStrict
BenchmarkConcurrentSetAndCheckStrict-32      	2059890	      567.1 ns/op	     63 B/op	      5 allocs/op
BenchmarkConcurrentPeek
BenchmarkConcurrentPeek-32                   	6792751	      182.3 ns/op	      0 B/op	      0 allocs/op
PASS
```

## This PR

```
goos: linux
goarch: amd64
pkg: github.com/yunginnanet/Rate5
cpu: 13th Gen Intel(R) Core(TM) i9-13900K
BenchmarkCheck
BenchmarkCheck-32                            	4973056	      241.4 ns/op	     32 B/op	      2 allocs/op
BenchmarkCheckHardcore
BenchmarkCheckHardcore-32                    	2726428	      437.1 ns/op	     40 B/op	      2 allocs/op
BenchmarkCheckStrict
BenchmarkCheckStrict-32                      	2737549	      437.8 ns/op	     40 B/op	      2 allocs/op
BenchmarkCheckStringer
BenchmarkCheckStringer-32                    	4440523	      265.9 ns/op	     48 B/op	      3 allocs/op
BenchmarkPeek
BenchmarkPeek-32                             	13621988	       89.78 ns/op	      0 B/op	      0 allocs/op
BenchmarkConcurrentCheck
BenchmarkConcurrentCheck-32                  	2956100	      411.5 ns/op	     32 B/op	      2 allocs/op
BenchmarkConcurrentSetAndCheckHardcore
BenchmarkConcurrentSetAndCheckHardcore-32    	1656236	      697.8 ns/op	     40 B/op	      3 allocs/op
BenchmarkConcurrentSetAndCheckStrict
BenchmarkConcurrentSetAndCheckStrict-32      	1703101	      722.1 ns/op	     40 B/op	      3 allocs/op
BenchmarkConcurrentPeek
BenchmarkConcurrentPeek-32                   	6395762	      174.7 ns/op	      0 B/op	      0 allocs/op
```
